### PR TITLE
Switch away from running the service as root

### DIFF
--- a/relay.service
+++ b/relay.service
@@ -2,8 +2,8 @@
 Description=Start the startup.py script for relay control functionality
 
 [Service]
-User=root
-Group=root
+User=relay
+Group=relay
 ExecStart=/opt/startup/startup.py
 
 [Install]

--- a/relaypi.yaml
+++ b/relaypi.yaml
@@ -12,7 +12,6 @@
 
   tasks:
 
-  #TODO: switch away from using root to actually using user relay, startup.py currently depends on accessing /dev/mem
   - name: Add the group 'relay'
     group:
       name: relay
@@ -21,7 +20,9 @@
   - name: Add the user 'relay'
     ansible.builtin.user:
       name: relay
-      groups: relay
+      groups:
+        - relay
+        - gpio
       shell: /sbin/nologin
       append: yes
     become: yes
@@ -134,7 +135,6 @@
       group: relay
       owner: relay
 
-  #TODO: if using /dev/mem is necessary, edit relay.service to run as User=relay and Group=root, if not edit to User=relay and Group=relay
   - name: Download the relay.service systemd service
     get_url:
       url: https://www.sasaa.nl/.raspi/relay.service


### PR DESCRIPTION
added user `relay` to group `gpio` allowing it to access `/dev/gpiomem` to allow `startup.py` to run unprivileged, edited `relay.service` to reflect the change, cleaned up playbook